### PR TITLE
Allow manual trigger of release publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -23,7 +24,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/examples/benches/benchmark.rs
+++ b/examples/benches/benchmark.rs
@@ -24,8 +24,7 @@ fn benchmark_run_client(c: &mut Criterion) {
     group.bench_function("run_client", |b| {
         b.iter(|| {
             let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
-            let _ =
-                runtime.block_on(async { black_box(run_client("http://0.0.0.0:50051")).await });
+            let _ = runtime.block_on(async { black_box(run_client("http://0.0.0.0:50051")).await });
         })
     });
 


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to `release.yml`
- Allow `publish` job to run on manual dispatch (not just release-please)

Needed to publish `v2.0.0` to crates.io since the release was created manually.

## Test plan

- [ ] Merge this PR
- [ ] Trigger release workflow manually via `gh workflow run release.yml`
- [ ] Verify `publish` job runs and publishes to crates.io