### PR TITLE
Fix: use existing CRATES_IO_TOKEN secret for cargo publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Publish to crates.io
         run: cargo publish --manifest-path gmf/Cargo.toml
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -23,7 +24,7 @@ jobs:
 
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/examples/benches/benchmark.rs
+++ b/examples/benches/benchmark.rs
@@ -24,8 +24,7 @@ fn benchmark_run_client(c: &mut Criterion) {
     group.bench_function("run_client", |b| {
         b.iter(|| {
             let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
-            let _ =
-                runtime.block_on(async { black_box(run_client("http://0.0.0.0:50051")).await });
+            let _ = runtime.block_on(async { black_box(run_client("http://0.0.0.0:50051")).await });
         })
     });
 


### PR DESCRIPTION
The publish job referenced `CARGO_REGISTRY_TOKEN` but the repo has `CRATES_IO_TOKEN` configured.